### PR TITLE
Use mime-type given by fedora for R datastreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@ Disadis
 =======
 
 Disadis is an authorization proxy for Hydra-based applications.
-It is designed to proxy content out of Fedora,
-or to verify authorization and redirect requests to other content delivery methods.
-Disadis takes the burden of downloads from the hydra application.
-It is designed to be fast, as well as understanding `hydraRightsmetadata` datastreams.
-It can be adapted to work with different ways of indication user identity in the request.
-At the moment it supports rails cookies and [auth-pubtkt](https://neon1.net/mod_auth_pubtkt/) headers.
+It will proxy content out of a Fedora 3 instance, so your Ruby application doesn't have to
+use a valuable instance doing an otherwise mindless task.
+Our preferred setup is to have the rails application handle the download request and
+then, if everything is ok, use an nginx internal redirect to ask disadis to start and
+monitor the actual download to the client.
+Disadis can also verify authorization and understands the Hydra `rightsMetadata` datastream
+a limited amount.
 
 Disadis
 
@@ -15,6 +16,7 @@ Disadis
 * provides E-tags.
 * responds to `GET` and `HEAD` requests.
 * assumes the filename is the label of the datastream.
+* handles range requests
 
 Each handler can optionally use authorization or not.
 This way, say, thumbnails can just be served without doing any authorization.
@@ -84,10 +86,6 @@ location ^~ /downloads/ {
 
 # Future
 
-* Range requests
-* [X-Acel-Redirect](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ignore_headers)
-* Verify CAS tickets
-* Support more than one authorization method
 * Is there a simpler way to configure the whole thing? It seems too complicated to me.
 * Support config reloading and graceful shutdowns
 * Add metrics to track the cache hit/miss rates

--- a/download.go
+++ b/download.go
@@ -153,7 +153,7 @@ func (dh *DownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// sometimes fedora appends an extra extension. See FCREPO-497 in the
 	// fedora commons JIRA. This is why we pull the filename directly from
 	// the datastream label.
-	w.Header().Set("Content-Type", info.Type)
+	w.Header().Set("Content-Type", dsinfo.MIMEType)
 	// This is set by ServeContent()
 	//w.Header().Set("Content-Length", info.Length)
 	w.Header().Set("Content-Disposition", `inline; filename="`+dsinfo.Label+`"`)

--- a/fedora/fedora.go
+++ b/fedora/fedora.go
@@ -92,10 +92,13 @@ func (rf *remoteFedora) GetDatastream(id, dsname string) (io.ReadCloser, Content
 // DsInfo holds more complete metadata on a datastream (as opposed to the
 // ContentInfo structure)
 type DsInfo struct {
-	Label     string `xml:"dsLabel"`
-	VersionID string `xml:"dsVersionID"`
-	State     string `xml:"dsState"`
-	Checksum  string `xml:"dsChecksum"`
+	Label        string `xml:"dsLabel"`
+	VersionID    string `xml:"dsVersionID"`
+	State        string `xml:"dsState"`
+	Checksum     string `xml:"dsChecksum"`
+	MIMEType     string `xml:"dsMIME"`
+	Location     string `xml:"dsLocation"`
+	LocationType string `xml:"dsLocationType"`
 }
 
 func (rf *remoteFedora) GetDatastreamInfo(id, dsname string) (DsInfo, error) {

--- a/fedora/fedora.go
+++ b/fedora/fedora.go
@@ -146,14 +146,19 @@ func (info DsInfo) Version() int {
 
 // NewTestFedora creates an empty TestFedora object.
 func NewTestFedora() *TestFedora {
-	return &TestFedora{data: make(map[string][]byte)}
+	return &TestFedora{data: make(map[string]dspair)}
 }
 
 // TestFedora implements a simple in-memory Fedora stub which will return bytes which have
 // already been specified by Set().
 // Intended for testing. (Maybe move to a testing file?)
 type TestFedora struct {
-	data map[string][]byte
+	data map[string]dspair
+}
+
+type dspair struct {
+	info    DsInfo
+	content []byte
 }
 
 // GetDatastream returns a ReadCloser which holds the content of the named
@@ -166,27 +171,34 @@ func (tf *TestFedora) GetDatastream(id, dsname string) (io.ReadCloser, ContentIn
 		return nil, ci, ErrNotFound
 	}
 	ci.Type = "text/plain"
-	ci.Length = fmt.Sprintf("%d", len(v))
-	return ioutil.NopCloser(bytes.NewReader(v)), ci, nil
+	ci.Length = fmt.Sprintf("%d", len(v.content))
+	return ioutil.NopCloser(bytes.NewReader(v.content)), ci, nil
 }
 
 // GetDatastreamInfo returns Fedora's metadata for the given datastream.
 func (tf *TestFedora) GetDatastreamInfo(id, dsname string) (DsInfo, error) {
 	key := id + "/" + dsname
-	_, ok := tf.data[key]
+	v, ok := tf.data[key]
 	if !ok {
 		return DsInfo{}, ErrNotFound
 	}
-	return DsInfo{
-		Label:     "",
-		VersionID: dsname + ".0",
-		State:     "A",
-		Checksum:  "",
-	}, nil
+	return v.info, nil
 }
 
 // Set the given datastream to have the given content.
-func (tf *TestFedora) Set(id, dsname string, value []byte) {
+func (tf *TestFedora) Set(id, dsname string, info DsInfo, value []byte) {
+	if info.State == "" {
+		info.State = "A"
+	}
+	if info.VersionID == "" {
+		info.VersionID = dsname + ".0"
+	}
+	if info.Location == "" {
+		info.Location = fmt.Sprintf("%s+%s+%s", id, dsname, info.VersionID)
+	}
+	if info.LocationType == "" {
+		info.LocationType = "INTERNAL_ID"
+	}
 	key := id + "/" + dsname
-	tf.data[key] = value
+	tf.data[key] = dspair{info, value}
 }

--- a/fedora/fedora.go
+++ b/fedora/fedora.go
@@ -146,17 +146,17 @@ func (info DsInfo) Version() int {
 
 // NewTestFedora creates an empty TestFedora object.
 func NewTestFedora() *TestFedora {
-	return &TestFedora{data: make(map[string]dspair)}
+	return &TestFedora{data: make(map[string]dsPair)}
 }
 
 // TestFedora implements a simple in-memory Fedora stub which will return bytes which have
 // already been specified by Set().
 // Intended for testing. (Maybe move to a testing file?)
 type TestFedora struct {
-	data map[string]dspair
+	data map[string]dsPair
 }
 
-type dspair struct {
+type dsPair struct {
 	info    DsInfo
 	content []byte
 }
@@ -200,5 +200,5 @@ func (tf *TestFedora) Set(id, dsname string, info DsInfo, value []byte) {
 		info.LocationType = "INTERNAL_ID"
 	}
 	key := id + "/" + dsname
-	tf.data[key] = dspair{info, value}
+	tf.data[key] = dsPair{info, value}
 }


### PR DESCRIPTION
Always pull the content type to return to the downloader from the fedora datastream metadata, and don't use the `Content-Type` header returned with the content. If the datastream is of type `R` then the content-type header received is from the source of the data and not from fedora, and the two probably don't match.

DLTP-568