### PR TITLE
Etag short circuit

### DIFF
--- a/download.go
+++ b/download.go
@@ -71,7 +71,8 @@ func notFound(w http.ResponseWriter) {
 
 func (dh *DownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" && r.Method != "HEAD" {
-		notFound(w)
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "405 Method Not Allowed", http.StatusMethodNotAllowed)
 		return
 	}
 

--- a/download.go
+++ b/download.go
@@ -65,10 +65,6 @@ type DownloadHandler struct {
 	Auth      *auth.HydraAuth
 }
 
-func notFound(w http.ResponseWriter) {
-	http.Error(w, "404 Not Found", http.StatusNotFound)
-}
-
 func (dh *DownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" && r.Method != "HEAD" {
 		w.Header().Set("Allow", "GET, HEAD")
@@ -86,7 +82,7 @@ func (dh *DownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// will an identifier ever have more than 64 characters?
 	if len(components[0]) == 0 || len(components[0]) > 64 {
-		notFound(w)
+		http.NotFound(w, r)
 		return
 	}
 
@@ -102,7 +98,7 @@ func (dh *DownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "401 Unauthorized", http.StatusUnauthorized)
 			return
 		case auth.AuthNotFound:
-			notFound(w)
+			http.NotFound(w, r)
 			return
 		case auth.AuthAllow:
 			break
@@ -118,7 +114,7 @@ func (dh *DownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var err error
 		version, err = strconv.Atoi(components[1])
 		if err != nil || version < 0 {
-			notFound(w)
+			http.NotFound(w, r)
 			return
 		}
 	}
@@ -127,7 +123,7 @@ func (dh *DownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	dsinfo, err := dh.Fedora.GetDatastreamInfo(pid, dh.Ds)
 	if err != nil {
 		log.Printf("Received Fedora error (%s,%s): %s", pid, dh.Ds, err.Error())
-		notFound(w)
+		http.NotFound(w, r)
 		return
 	}
 
@@ -144,7 +140,7 @@ func (dh *DownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err {
 		case fedora.ErrNotFound:
-			notFound(w)
+			http.NotFound(w, r)
 			return
 		default:
 			log.Println("Received fedora error:", err)

--- a/download_test.go
+++ b/download_test.go
@@ -32,7 +32,7 @@ func TestDownload(t *testing.T) {
 		{"HEAD", "/123/0", 200, ""},
 
 		{"GET", "/0123?datastream_id=content", 200, "hello"},
-		{"POST", "/0123", 404, ""},
+		{"POST", "/0123", 405, ""},
 
 		{"GET", "/badsize", 200, "hola"},
 

--- a/mux.go
+++ b/mux.go
@@ -54,7 +54,7 @@ func (dm *DsidMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if dm.DefaultHandler != nil {
 			dm.DefaultHandler.ServeHTTP(w, r)
 		} else {
-			notFound(w)
+			http.NotFound(w, r)
 		}
 		return
 	}
@@ -64,5 +64,5 @@ func (dm *DsidMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	notFound(w)
+	http.NotFound(w, r)
 }


### PR DESCRIPTION
Add a simple etag check before we try to stream content. This is an opportunistic optimization.

A few other changes too:

* Rearrange the version checking code so it is all together. If it weren't for vecnet, it would be worthwhile to think about removing the feature altogether.
* Return 405 (Method Not Supported) for non `GET` or `HEAD` requests. (prev was 404)
* Use the `net/http` version of `NotFound` instead of our own.

