### PR TITLE
Send bendo token

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ The file gives how to determine the current user from a request, the handlers to
 set up, and the URL to use to address fedora.
 
 The configuration file consists of a number of sections, which may appear in any order.
-The first section `[general]` has two variables to set:
+The first section `[general]` has three variables to set:
 
  * `log-filename` is the name of the log file to use. If none is provided, logging is sent to `stdout`.
  * `fedora-addr` is the root URL to use to access your fedora instance.
  It should include the fedora username and password if those are needed to download content from your fedora.
+* `bendo-token` is a token to use for content stored at external URLs via E or R datastreams. (optional)
 
 Sample section:
 

--- a/disadis.go
+++ b/disadis.go
@@ -86,6 +86,7 @@ type config struct {
 		Log_filename string
 		Fedora_addr  string
 		Admin        []string
+		Bendo_token  string
 	}
 	Pubtkt struct {
 		Key_file string
@@ -171,6 +172,9 @@ func main() {
 	default:
 		log.Printf("Warning: No authorization method given.")
 	}
+	if config.General.Bendo_token != "" {
+		log.Println("Bendo token supplied")
+	}
 	if len(config.Handler) == 0 {
 		log.Printf("No Handlers are defined. Exiting.")
 		return
@@ -195,10 +199,11 @@ func runHandlers(config config, fedora fedora.Fedora, auth *auth.HydraAuth) {
 	// first create the handlers
 	for k, v := range config.Handler {
 		h := &DownloadHandler{
-			Fedora:    fedora,
-			Ds:        v.Datastream,
-			Versioned: v.Versioned,
-			Prefix:    v.Prefix,
+			Fedora:     fedora,
+			Ds:         v.Datastream,
+			Versioned:  v.Versioned,
+			Prefix:     v.Prefix,
+			BendoToken: config.General.Bendo_token,
 		}
 		if v.Auth {
 			h.Auth = auth


### PR DESCRIPTION
Add optional config to set a token that will be passed to any redirected datastreams. This is in preparation of locking down the bendo access routes.