### PR TITLE
Try to read the bendo headers from fedora

### DIFF
--- a/fedora/fedora.go
+++ b/fedora/fedora.go
@@ -88,6 +88,10 @@ func (rf *remoteFedora) GetDatastream(id, dsname string) (io.ReadCloser, Content
 	info.Type = r.Header.Get("Content-Type")
 	info.Length = r.Header.Get("Content-Length")
 	info.Disposition = r.Header.Get("Content-Disposition")
+	// Try to read the the checksums in case this is an R datastream and we
+	// were redirected to bendo
+	info.MD5 = r.Header.Get("X-Content-Md5")
+	info.SHA256 = r.Header.Get("X-Content-Sha256")
 	return r.Body, info, nil
 }
 


### PR DESCRIPTION
If we are following a fedora R datastream and were not configured with a
bendo token, we use fedora to do the redirect. In this case, try to read
the checksum information from (redirected) fedora request.

DLTP-1791