### PR TITLE
Try not to abort zip downloads on errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
- - 1.9.4
- - 1.12.9
- - 1.13.10
- - 1.14.2
+ - 1.13.3   # buildimage version
+ - 1.13.11
+ - 1.14.3
 install: true
 script: go test -v . ./fedora

--- a/download_test.go
+++ b/download_test.go
@@ -31,17 +31,17 @@ func TestDownload(t *testing.T) {
 		{"GET", "/badsize", 200, "hola"},
 
 		{"GET", "/0123/zip/123,0123", 200, ""},
-		{"GET", "/0123/zip/123,0124", 404, ""},
+		{"GET", "/0123/zip/123,0124", 200, ""},
 
 		// It applies the correct prefix
 		{"GET", "/xyz", 404, ""},
 		{"HEAD", "/xyz", 404, ""},
 
 		{"GET", "/123/zip/123,0123", 200, ""},
-		{"GET", "/123/zip/123,0124", 404, ""},
+		{"GET", "/123/zip/123,0124", 200, ""},
 
 		// identifiers are assumed to not have more than 64 characters
-		{"GET", "/123456789012345678901234567890123456789012345678901234567890", 404, ""},
+		{"GET", "/1234567890123456789012345678901234567890123456789012345678901234567890", 404, ""},
 	}
 	for _, s := range sequence {
 		checkRoute(t, s.verb, ts.URL+s.route, s.status, s.expected)


### PR DESCRIPTION
* Change error handling in zips so we skip included files on errors,
instead of aborting the entire download.
* Set "modified time" for files in zip archive. Of course for now we
  just use the current time. But better than December of 1979.
* Set archive comments that this was downloaded from CurateND
* Explicitly close files as we add them to the archive.